### PR TITLE
start non-core informers in test, remove controller start from contro…

### DIFF
--- a/pkg/serviceaccounts/controllers/docker_registry_service_test.go
+++ b/pkg/serviceaccounts/controllers/docker_registry_service_test.go
@@ -58,6 +58,7 @@ func controllerSetup(startingObjects []runtime.Object, t *testing.T) (*fake.Clie
 
 	stopChan := make(<-chan struct{})
 	informerFactory.StartCore(stopChan)
+	informerFactory.Start(stopChan)
 
 	return kubeclient, fakeWatch, controller
 }


### PR DESCRIPTION
…ller, index sa token secrets

```
[pweil@localhost origin]$ ./hack/test-go.sh ./pkg/serviceaccounts/controllers
ok  	github.com/openshift/origin/pkg/serviceaccounts/controllers	1.976s	coverage: 39.1% of statements
./hack/test-go.sh succeeded after 6 seconds
```